### PR TITLE
:sparkles: feat: 공통 Layout 설정

### DIFF
--- a/src/components/HiPageComponent.tsx
+++ b/src/components/HiPageComponent.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const HiPageComponent = () => {
+  return (
+    <>
+      <span>hi</span>
+    </>
+  );
+};

--- a/src/components/IndexPageComponent.tsx
+++ b/src/components/IndexPageComponent.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const IndexPageComponent = () => {
+  return (
+    <>
+      <span>index</span>
+    </>
+  );
+};

--- a/src/components/IndexPageComponent.tsx
+++ b/src/components/IndexPageComponent.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export const IndexPageComponent = () => {
   return (
     <>
-      <span>index</span>
+      <span>main</span>
     </>
   );
 };

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -9,23 +9,20 @@ export const DefaultLayout = ({ children }: DefaultLayoutProps) => {
   return (
     <DefaultLayoutContainer>
       <Header />
-      <DefaultLayoutMain>{children}</DefaultLayoutMain>
+      <DefaultLayoutContent>{children}</DefaultLayoutContent>
     </DefaultLayoutContainer>
   );
 };
 
-const DefaultLayoutContainer = styled("div")`
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-`;
+const DefaultLayoutContainer = styled("div")``;
 
 const Header = styled("header")`
   height: 72px;
   background-color: green;
 `;
 
-const DefaultLayoutMain = styled("main")`
+const DefaultLayoutContent = styled("main")`
+  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -18,7 +18,6 @@ const DefaultLayoutContainer = styled("div")``;
 
 const Header = styled("header")`
   height: 72px;
-  background-color: green;
 `;
 
 const DefaultLayoutContent = styled("main")`
@@ -27,6 +26,5 @@ const DefaultLayoutContent = styled("main")`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color: salmon;
   margin: 0 120px;
 `;

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+import React from "react";
+
+interface DefaultLayoutProps {
+  children?: React.ReactNode;
+}
+
+export const DefaultLayout = ({ children }: DefaultLayoutProps) => {
+  return (
+    <DefaultLayoutContainer>
+      <Header />
+      <DefaultLayoutMain>{children}</DefaultLayoutMain>
+    </DefaultLayoutContainer>
+  );
+};
+
+const DefaultLayoutContainer = styled("div")`
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Header = styled("header")`
+  height: 72px;
+  background-color: green;
+`;
+
+const DefaultLayoutMain = styled("main")`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: salmon;
+  margin: 0 242px;
+`;

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -28,5 +28,5 @@ const DefaultLayoutContent = styled("main")`
   justify-content: center;
   align-items: center;
   background-color: salmon;
-  margin: 0 242px;
+  margin: 0 120px;
 `;

--- a/src/layouts/HeaderLayout.tsx
+++ b/src/layouts/HeaderLayout.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styled from "styled-components";
+
+export default function MainLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Header />
+      <Carousel />
+      <MainLayoutRootContainer>
+        <LayoutMainContainer>{children}</LayoutMainContainer>
+      </MainLayoutRootContainer>
+    </>
+  );
+}
+
+const MainLayoutRootContainer = styled("div")`
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Header = styled("header")`
+  height: 72px;
+  background-color: green;
+`;
+
+const Carousel = styled("div")`
+  height: 272px;
+  background-color: blue;
+`;
+
+const LayoutMainContainer = styled("main")`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: salmon;
+  margin: 0 242px;
+`;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -39,5 +39,5 @@ const MainLayoutContent = styled("main")`
   justify-content: center;
   align-items: center;
   background-color: salmon;
-  margin: 0 242px;
+  margin: 0 120px;
 `;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -11,14 +11,13 @@ export default function MainLayout({
       <Header />
       <Carousel />
       <MainLayoutRootContainer>
-        <LayoutMainContainer>{children}</LayoutMainContainer>
+        <MainLayoutContent>{children}</MainLayoutContent>
       </MainLayoutRootContainer>
     </>
   );
 }
 
 const MainLayoutRootContainer = styled("div")`
-  height: 100vh;
   display: flex;
   flex-direction: column;
 `;
@@ -33,7 +32,8 @@ const Carousel = styled("div")`
   background-color: blue;
 `;
 
-const LayoutMainContainer = styled("main")`
+const MainLayoutContent = styled("main")`
+  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -29,7 +29,6 @@ const Header = styled("header")`
 
 const Carousel = styled("div")`
   height: 272px;
-  background-color: blue;
 `;
 
 const MainLayoutContent = styled("main")`
@@ -38,6 +37,5 @@ const MainLayoutContent = styled("main")`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color: salmon;
   margin: 0 120px;
 `;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,6 +27,7 @@ type AppPropsWithLayout = {
   };
 
 function MoyeoApp({ Component, pageProps }: AppPropsWithLayout) {
+  const { dehydratedState, ...rest } = pageProps;
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -44,10 +45,9 @@ function MoyeoApp({ Component, pageProps }: AppPropsWithLayout) {
     <ThemeProvider theme={Theme}>
       <GlobalStyle />
       <QueryClientProvider client={queryClient}>
-        <Hydrate state={pageProps.dehydratedState}>
+        <Hydrate state={dehydratedState}>
           <RecoilRoot>
-            {/* TODO: type error */}
-            <Component {...pageProps} />
+            <Component {...rest} />
           </RecoilRoot>
         </Hydrate>
       </QueryClientProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,20 +7,26 @@ import {
   QueryClientProvider,
 } from "@tanstack/react-query";
 import type { AppProps } from "next/app";
-import { NextPageContext } from "next/types";
+import { NextPage, NextPageContext } from "next/types";
 import { useState } from "react";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyle, Theme } from "jci-moyeo-design-system";
 
-type PageProps = {
-  dehydratedState?: DehydratedState;
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  // eslint-disable-next-line no-unused-vars
+  getLayout?: (page: React.ReactElement) => React.ReactNode;
 };
 
-type ExtendedAppProps<P = unknown> = {
+type AppPropsWithLayout = {
   err?: NextPageContext["err"];
-} & AppProps<P>;
+} & AppProps<{
+  dehydratedState?: DehydratedState;
+}> & {
+    Component: NextPageWithLayout;
+  };
 
-function MoyeoApp({ Component, pageProps }: ExtendedAppProps<PageProps>) {
+function MoyeoApp({ Component, pageProps }: AppPropsWithLayout) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -32,17 +38,20 @@ function MoyeoApp({ Component, pageProps }: ExtendedAppProps<PageProps>) {
       }),
   );
 
-  return (
+  const getLayout = Component.getLayout ?? ((page) => page);
+
+  return getLayout(
     <ThemeProvider theme={Theme}>
       <GlobalStyle />
       <QueryClientProvider client={queryClient}>
         <Hydrate state={pageProps.dehydratedState}>
           <RecoilRoot>
+            {/* TODO: type error */}
             <Component {...pageProps} />
           </RecoilRoot>
         </Hydrate>
       </QueryClientProvider>
-    </ThemeProvider>
+    </ThemeProvider>,
   );
 }
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,23 +4,23 @@ import Document, {
   Html,
   Main,
   NextScript,
-} from 'next/document'
-import React from 'react'
-import { ServerStyleSheet } from 'styled-components'
+} from "next/document";
+import React from "react";
+import { ServerStyleSheet } from "styled-components";
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
-    const sheet = new ServerStyleSheet()
-    const originalRenderPage = ctx.renderPage
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
 
     try {
       ctx.renderPage = () =>
         originalRenderPage({
           enhanceApp: (App) => (props) =>
             sheet.collectStyles(<App {...props} />),
-        })
+        });
 
-      const initialProps = await Document.getInitialProps(ctx)
+      const initialProps = await Document.getInitialProps(ctx);
       return {
         ...initialProps,
         styles: (
@@ -29,9 +29,9 @@ class MyDocument extends Document {
             {sheet.getStyleElement()}
           </>
         ),
-      }
+      };
     } finally {
-      sheet.seal()
+      sheet.seal();
     }
   }
 
@@ -44,8 +44,8 @@ class MyDocument extends Document {
           <NextScript />
         </body>
       </Html>
-    )
+    );
   }
 }
 
-export default MyDocument
+export default MyDocument;

--- a/src/pages/hi/index.tsx
+++ b/src/pages/hi/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { DefaultLayout } from "layouts/DefaultLayout";
+import { NextPageWithLayout } from "pages/_app";
+import { HiPageComponent } from "components/HiPageComponent";
+
+const Hi: NextPageWithLayout = () => {
+  return <HiPageComponent />;
+};
+
+Hi.getLayout = (page) => {
+  return <DefaultLayout>{page}</DefaultLayout>;
+};
+
+export default Hi;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { NextPageWithLayout } from "./_app";
 import { IndexPageComponent } from "components/IndexPageComponent";
-import MainLayout from "layouts/HeaderLayout";
+import MainLayout from "layouts/MainLayout";
 
 const Index: NextPageWithLayout = () => {
   return <IndexPageComponent />;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-import { NextPage } from "next";
-import { Card } from "jci-moyeo-design-system";
+import { NextPageWithLayout } from "./_app";
+import { IndexPageComponent } from "components/IndexPageComponent";
+import MainLayout from "layouts/HeaderLayout";
 
-const Home: NextPage = () => {
-  return (
-    <div>
-      <Card>Test</Card>
-    </div>
-  );
+const Index: NextPageWithLayout = () => {
+  return <IndexPageComponent />;
 };
 
-export default Home;
+Index.getLayout = (page) => {
+  return <MainLayout>{page}</MainLayout>;
+};
+
+export default Index;


### PR DESCRIPTION
## 설명

- 공통 Layout를 설정했습니다.

## 작업내용

- `pages` 밑에서 layout과 component를 import하는 구조입니다.
- DefaultLayout, MainLayout을 설정했습니다.

## 참고사항 (Optional)

- `_app.tsx` 에서 getLayout해주는 부분이랑 tanstack query 타입지정부분에서 뭔가 충돌이 나는지 타입에러가 나는데 아시는 분 있으면 도움 부탁드립니다 🥲

## 스크린샷 (Optional)

- 초록색 영역 : `Header`
- 파란색 영역 : `Carousel`

### DefaultLayout (Header)
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/66931791/195533243-b5ff6a6f-4576-4874-8121-1b76db25c319.png">


### MainLayout (Header + Carousel)
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/66931791/195533314-3b3fb41a-c29e-41c8-a22e-ccba9d5a6b53.png">