### PR TITLE
feature: SkillItem 컴포넌트 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,9 @@ const nextConfig = {
     });
     return config;
   },
+  images: {
+    domains: ["moyeo-skillstack.s3.ap-northeast-2.amazonaws.com"],
+  },
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/styled-components": "^5.1.26",
     "axios": "^0.27.2",
     "formik": "^2.2.9",
-    "jci-moyeo-design-system": "^0.2.1",
+    "jci-moyeo-design-system": "^0.2.2",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/components/post/SkillItem.tsx
+++ b/src/components/post/SkillItem.tsx
@@ -27,6 +27,6 @@ const ImageWrapper = styled.div`
   align-items: center;
   justify-content: center;
   border: 1px solid ${({ theme }) => theme.colors.general[300]};
-  border-radius: 50%;
+  border-radius: 999px;
   overflow: hidden;
 `;

--- a/src/components/post/SkillItem.tsx
+++ b/src/components/post/SkillItem.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Image from "next/image";
+import styled from "styled-components";
+import { Tooltip } from "jci-moyeo-design-system";
+
+export interface SkillItemProps {
+  name: string;
+  src: string;
+}
+
+const SkillItem = ({ name, src }: SkillItemProps) => {
+  return (
+    <Tooltip
+      content={name}
+      // eslint-disable-next-line react/no-children-prop
+      children={<StyledImage src={src} alt={name} width="36px" height="36px" />}
+    />
+  );
+};
+
+export default SkillItem;
+
+const StyledImage = styled(Image)`
+  width: 36px;
+  height: 36px;
+  border: 1px solid ${({ theme }) => theme.colors.general[300]};
+  border-radius: 50%;
+`;

--- a/src/components/post/SkillItem.tsx
+++ b/src/components/post/SkillItem.tsx
@@ -11,7 +11,7 @@ export interface SkillItemProps {
 const SkillItem = ({ name, src }: SkillItemProps) => {
   return (
     <Tooltip content={name}>
-      <ImageWrapper>
+      <ImageWrapper role="img" aria-label={name}>
         <Image src={src} alt={name} width="30px" height="30px" />
       </ImageWrapper>
     </Tooltip>

--- a/src/components/post/SkillItem.tsx
+++ b/src/components/post/SkillItem.tsx
@@ -13,16 +13,24 @@ const SkillItem = ({ name, src }: SkillItemProps) => {
     <Tooltip
       content={name}
       // eslint-disable-next-line react/no-children-prop
-      children={<StyledImage src={src} alt={name} width="36px" height="36px" />}
+      children={
+        <ImageWrapper>
+          <Image src={src} alt={name} width="30px" height="30px" />
+        </ImageWrapper>
+      }
     />
   );
 };
 
 export default SkillItem;
 
-const StyledImage = styled(Image)`
+const ImageWrapper = styled.div`
   width: 36px;
   height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid ${({ theme }) => theme.colors.general[300]};
   border-radius: 50%;
+  overflow: hidden;
 `;

--- a/src/components/post/SkillItem.tsx
+++ b/src/components/post/SkillItem.tsx
@@ -10,15 +10,11 @@ export interface SkillItemProps {
 
 const SkillItem = ({ name, src }: SkillItemProps) => {
   return (
-    <Tooltip
-      content={name}
-      // eslint-disable-next-line react/no-children-prop
-      children={
-        <ImageWrapper>
-          <Image src={src} alt={name} width="30px" height="30px" />
-        </ImageWrapper>
-      }
-    />
+    <Tooltip content={name}>
+      <ImageWrapper>
+        <Image src={src} alt={name} width="30px" height="30px" />
+      </ImageWrapper>
+    </Tooltip>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2849,10 +2849,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-jci-moyeo-design-system@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/jci-moyeo-design-system/-/jci-moyeo-design-system-0.2.1.tgz#9eff1961163d4f4edf6cf03943ae4dd0caeda332"
-  integrity sha512-Ln2in1fLLTG0S43BizAJgQpXsyXez6XBxUsCLa9ppte6HbQ7r6BsV+KKSva3yO3t3+x+yDfU/5s79fkWTN/adg==
+jci-moyeo-design-system@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/jci-moyeo-design-system/-/jci-moyeo-design-system-0.2.2.tgz#45ff2dc8d4520df9c615f580c4be4c49090427b7"
+  integrity sha512-sFwPYMMEZBpyvnVERBqMbN+XyKjLBQzorGx0SyGAVXvKD1Wk9Se8L5AUVibvfLT7euniZ4bYRmaBcdSz9Qz5oA==
 
 js-sdsl@^4.1.4:
   version "4.1.4"


### PR DESCRIPTION
## 설명
- `SkillItem` 컴포넌트를 구현합니다.

## 작업내용
- `SkillItem` 컴포넌트 구현
- `next.config.js` 기술 이미지 도메인 설정
- 
## 참고사항 (Optional)
- `SkillItem` 컴포넌트는 모집글에서만 사용하므로 `post` 폴더 안에 생성했습니다.
- 컴포넌트가 위 아래로 나란히 있는 경우 tooltip이 겹치게 보이는 문제가 있습니다. 디자인 시스템 수정을 하도록 하겠습니다.
   <img width="131" alt="스크린샷 2022-10-20 오후 6 23 15" src="https://user-images.githubusercontent.com/12439567/196919977-9f20dab1-d0cc-4855-ad74-30353a59da8f.png">
- 피그마 같은 경우 36px로 설정하면 border와 겹쳐보이기 때문에 Image 컴포넌트는 약간의 여백을 주기위해 30px로 설정했습니다.

## 스크린샷 (Optional)
![Skill Icon](https://user-images.githubusercontent.com/12439567/196920443-3dbaa5b7-45c2-4677-811d-4a0720d52f2c.gif)

<!-- ## 링크 (Optional)

- 작업을 하면서 자신이 도움을 받았거나 리뷰어들이 PR에 대해 더욱 쉽게 이해를 할 수 있도록 링크를 추가해주세요. -->
