### PR TITLE
feature: Profile 상세 페이지 UI 구현

### DIFF
--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1,0 +1,116 @@
+import Section from "components/common/Section";
+import { Chip } from "jci-moyeo-design-system";
+import React from "react";
+import styled from "styled-components";
+
+const Profile = () => {
+  return (
+    <PageContainer>
+      <Title>
+        안녕하세요 <TitleNickname>모요미</TitleNickname>입니다.
+      </Title>
+      <UserContainer>
+        <Avatar />
+        <Nickname>모요미</Nickname>
+      </UserContainer>
+      <Info>
+        <SubTitle>기술 스택</SubTitle>
+        <SkillContainer>
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+          <Chip color="basic" variants="pill" label="React" />
+        </SkillContainer>
+      </Info>
+      <Info>
+        <SubTitle>자기소개</SubTitle>
+        {/* TODO: toast ui viewer로 대체 */}
+        <Section>
+          <Introduction>
+            제 인생에서 1차적인 목표인 장기복무 합격이 올해 이루어졌기 때문에
+            한동안 많은 생각을 하면서 다음 목표를 정하려고 노력했습니다. 그래서
+            생각한 것은 상사 진급 및 학사학위 취득입니다.
+          </Introduction>
+        </Section>
+      </Info>
+    </PageContainer>
+  );
+};
+
+export default Profile;
+
+const PageContainer = styled.div`
+  margin: 64px 0;
+`;
+
+const Title = styled.h1`
+  margin-bottom: 40px;
+  ${({ theme }) => theme.typography.header1};
+  color: ${({ theme }) => theme.colors.text.title};
+
+  @media (max-width: ${({ theme }) => `${theme.breakpoints.md - 1}px`}) {
+    margin-bottom: 32px;
+    ${({ theme }) => theme.typography.header2};
+  }
+`;
+
+const TitleNickname = styled.span`
+  color: ${({ theme }) => theme.colors.primary["500"]};
+`;
+
+const UserContainer = styled.div`
+  margin-bottom: 32px;
+  display: flex;
+  align-items: center;
+`;
+
+// TODO: Avatar 컴포넌트로 대체
+const Avatar = styled.span`
+  margin-right: 16px;
+  display: inline-block;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background-color: #d9d9d9;
+`;
+
+const Nickname = styled.span`
+  ${({ theme }) => theme.typography.header2};
+  color: ${({ theme }) => theme.colors.text.title};
+
+  @media (max-width: ${({ theme }) => `${theme.breakpoints.md - 1}px`}) {
+    ${({ theme }) => theme.typography.header3};
+  }
+`;
+
+const Info = styled.div`
+  margin-bottom: 36px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const SubTitle = styled.div`
+  margin-bottom: 12px;
+  ${({ theme }) => theme.typography.md};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+const SkillContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+`;
+
+const Introduction = styled.div`
+  margin: 20px 20px 32px 20px;
+  ${({ theme }) => theme.typography.sm};
+`;

--- a/src/components/profile/index.ts
+++ b/src/components/profile/index.ts
@@ -1,0 +1,1 @@
+export { default as Profile } from "./Profile";

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { DefaultLayout } from "layouts/DefaultLayout";
+import { NextPageWithLayout } from "pages/_app";
+import { Profile } from "components/profile";
+
+const ProfileDetail: NextPageWithLayout = () => {
+  return <Profile />;
+};
+
+ProfileDetail.getLayout = (page) => {
+  return <DefaultLayout>{page}</DefaultLayout>;
+};
+
+export default ProfileDetail;


### PR DESCRIPTION
## 설명
- Profile 상세 페이지 UI를 구현합니다.

## 작업내용
- Profile 상세 페이지 UI 구현

## 참고사항 (Optional)
- 공통으로 사용하는 Avatar 컴포넌트, Editor 컴포넌트 등이 머지되면 추후 반영할 예정입니다.
- 피그마에서는 연결 계정이 있는데, 타인의 계정을 노출하는 것은 개인정보 때문에 일단 제거한체로 UI 작업을 진행하였습니다.

## 스크린샷 (Optional)
<img width="1207" alt="스크린샷 2022-10-21 오전 12 12 47" src="https://user-images.githubusercontent.com/12439567/196988854-12c8cb55-5451-415c-9684-7d9c3964662a.png">

<img width="386" alt="스크린샷 2022-10-21 오전 12 13 02" src="https://user-images.githubusercontent.com/12439567/196988869-78e89953-f6f0-4b43-89a1-902b9c25625c.png">

<!-- ## 링크 (Optional)

- 작업을 하면서 자신이 도움을 받았거나 리뷰어들이 PR에 대해 더욱 쉽게 이해를 할 수 있도록 링크를 추가해주세요. -->
