### PR TITLE
feature: 마이페이지 UI 컴포넌트 대체

### DIFF
--- a/src/components/mypage/Info.tsx
+++ b/src/components/mypage/Info.tsx
@@ -1,8 +1,14 @@
 import Avatar from "components/common/Avatar";
+import Section from "components/common/Section";
 import { Button, Chip } from "jci-moyeo-design-system";
+import dynamic from "next/dynamic";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { InfoForm } from "./InfoForm";
+
+const Viewer = dynamic(() => import("../common/Viewer"), {
+  ssr: false,
+});
 
 export const myInfo = {
   nickname: "모요미",
@@ -53,7 +59,12 @@ export const Info = () => {
             />
           ))}
           <SubCategoryText>자기 소개</SubCategoryText>
-          <InfoText>{myInfo.info}</InfoText>
+          <Section>
+            <InfoText>
+              <Viewer initialValue={myInfo.info} />
+            </InfoText>
+          </Section>
+
           <MobileButton
             variants="outlined"
             color="general"
@@ -101,10 +112,6 @@ const StyledChip = styled(Chip)`
 `;
 
 const InfoText = styled("div")`
-  ${({ theme }) => theme.typography.sm};
-  color: ${({ theme }) => theme.colors.black[300]};
-  border: 1px solid ${({ theme }) => theme.colors.general["300"]};
-  border-radius: 4px;
   padding: 20px 20px 32px 20px;
 `;
 

--- a/src/components/mypage/Info.tsx
+++ b/src/components/mypage/Info.tsx
@@ -1,3 +1,4 @@
+import Avatar from "components/common/Avatar";
 import { Button, Chip } from "jci-moyeo-design-system";
 import React, { useState } from "react";
 import styled from "styled-components";
@@ -30,7 +31,7 @@ export const Info = () => {
         <>
           <ProfileContainer>
             <UserProfileContainer>
-              <ProfilePicture />
+              <Avatar id="" />
               <UserNickName>{myInfo.nickname}</UserNickName>
             </UserProfileContainer>
             <PcButton
@@ -80,15 +81,8 @@ export const UserProfileContainer = styled("div")`
   align-items: center;
 `;
 
-export const ProfilePicture = styled("div")`
-  width: 36px;
-  height: 36px;
-  margin-right: 16px;
-  border-radius: 9999px;
-  background-color: ${({ theme }) => theme.colors.primary[300]};
-`;
-
 export const UserNickName = styled("h2")`
+  margin-left: 16px;
   ${({ theme }) => theme.typography.header2};
 `;
 

--- a/src/components/mypage/ProjectStudy.tsx
+++ b/src/components/mypage/ProjectStudy.tsx
@@ -1,28 +1,6 @@
-import { PostCard } from "components/common/PostCard";
-import { Chip } from "jci-moyeo-design-system";
+import { PostList } from "components/common/PostList";
 import React from "react";
-import styled from "styled-components";
-
-export const post = {
-  title: "태블릿 펜을 이용한 그림심리 검사앱",
-  isScrap: true,
-  content: "작성일 2022.00.00 · 조회 33",
-  skills: ["php", "nodejs", "python"],
-};
 
 export const ProjectStudy = () => {
-  return (
-    // TODO: 그리드 컴포넌트로 수정예정
-    <PostCard
-      title={post?.title}
-      content={post?.content}
-      footer={post.skills.map((skill) => {
-        return <StyledChip key={skill} color="basic" label={skill} />;
-      })}
-    />
-  );
+  return <PostList postList={[]} />;
 };
-
-const StyledChip = styled(Chip)`
-  margin-right: 4px;
-`;

--- a/src/components/mypage/Scrap.tsx
+++ b/src/components/mypage/Scrap.tsx
@@ -1,29 +1,6 @@
-import { PostCard } from "components/common/PostCard";
-import { Chip, Icon, Theme } from "jci-moyeo-design-system";
+import { PostList } from "components/common/PostList";
 import React from "react";
-import styled from "styled-components";
-import { post } from "./ProjectStudy";
 
 export const Scrap = () => {
-  return (
-    // TODO: 그리드 컴포넌트로 수정예정
-    <PostCard
-      title={
-        <>
-          {post?.title}
-          {post?.isScrap && (
-            <Icon name="scrapOn" color={Theme.colors.primary[500]} />
-          )}
-        </>
-      }
-      content={post?.content}
-      footer={post.skills.map((skill) => {
-        return <StyledChip key={skill} color="basic" label={skill} />;
-      })}
-    />
-  );
+  return <PostList postList={[]} />;
 };
-
-const StyledChip = styled(Chip)`
-  margin-right: 4px;
-`;


### PR DESCRIPTION
## 설명
- 마이페이지에 있는 컴포넌트를 공통 컴포넌트로 대체합니다.

## 작업내용
- 내정보  `Avatar`, `Viewer`로 컴포넌트 대체
- 내 프로젝트/스터디 `PostList`로 대체
- 스크랩 `PostList`로 대체

## 참고사항 (Optional)
- 추후 내 프로필 조회, 내 프로젝트/스터디 조회, 내 스크랩 조회 API를 연동해야 합니다.
- 내정보 텍스트는 toast-ui에 영향을 받기 때문에 styled-component에서 정의한 속성은 일단 제거했습니다.

<!-- ## 스크린샷 (Optional)

- UI가 변경되었다면 사진이나 Gif를 추가해주세요. -->

<!-- ## 링크 (Optional)

- 작업을 하면서 자신이 도움을 받았거나 리뷰어들이 PR에 대해 더욱 쉽게 이해를 할 수 있도록 링크를 추가해주세요. -->
