### PR TITLE
:sparkles: feat: Modal.open

### DIFF
--- a/src/components/common/Modal/AlertModal.tsx
+++ b/src/components/common/Modal/AlertModal.tsx
@@ -8,32 +8,36 @@ export interface AlertModalProps {
   content?: string;
   icon?: React.ReactNode;
   // Todo: any 제거
-  confirmText?: string;
-  handleClose?: () => any;
-  handleConfirm?: () => any;
+  buttonText?: string;
+  onModalClose?: () => any;
+  onButtonClick?: () => any;
 }
 
 export const AlertModal = ({
   title,
   content,
   icon,
-  handleClose,
-  confirmText = "확인",
-  handleConfirm,
+  onModalClose,
+  buttonText: confirmText = "확인",
+  onButtonClick,
 }: AlertModalProps) => {
   const { close } = useModal();
 
   const onClose = () => {
-    if (handleClose) {
-      handleClose();
+    if (!onModalClose) {
+      return;
     }
+
+    onModalClose();
     close();
   };
 
-  const onConfirm = async () => {
-    if (handleConfirm) {
-      await handleConfirm();
+  const onConfirm = () => {
+    if (!onButtonClick) {
+      return;
     }
+
+    onButtonClick();
     close();
   };
 

--- a/src/components/common/Modal/AlertModal.tsx
+++ b/src/components/common/Modal/AlertModal.tsx
@@ -18,17 +18,15 @@ export const AlertModal = ({
   content,
   icon,
   onModalClose,
-  buttonText: confirmText = "확인",
+  buttonText = "확인",
   onButtonClick,
 }: AlertModalProps) => {
   const { close } = useModal();
 
   const onClose = () => {
-    if (!onModalClose) {
-      return;
+    if (onModalClose) {
+      onModalClose();
     }
-
-    onModalClose();
     close();
   };
 
@@ -36,19 +34,18 @@ export const AlertModal = ({
     if (!onButtonClick) {
       return;
     }
-
     onButtonClick();
     close();
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose}>
+    <Modal isOpen onClose={onClose}>
       <Modal.Content>
         <ModalContentContainer>
           <IconContainer>{icon}</IconContainer>
           <TitleContainer>{title}</TitleContainer>
           <ContentContainer>{content}</ContentContainer>
-          <Button onClick={onConfirm}>{confirmText}</Button>
+          <Button onClick={onConfirm}>{buttonText}</Button>
         </ModalContentContainer>
       </Modal.Content>
     </Modal>

--- a/src/components/common/Modal/AlertModal.tsx
+++ b/src/components/common/Modal/AlertModal.tsx
@@ -1,0 +1,82 @@
+import useModal from "hooks/useModal";
+import { Button, Modal } from "jci-moyeo-design-system";
+import React from "react";
+import styled from "styled-components";
+
+export interface AlertModalProps {
+  title?: string;
+  content?: string;
+  icon?: React.ReactNode;
+  // Todo: any 제거
+  confirmText?: string;
+  handleClose?: () => any;
+  handleConfirm?: () => any;
+}
+
+export const AlertModal = ({
+  title,
+  content,
+  icon,
+  handleClose,
+  confirmText = "확인",
+  handleConfirm,
+}: AlertModalProps) => {
+  const { close } = useModal();
+
+  const onClose = () => {
+    if (handleClose) {
+      handleClose();
+    }
+    close();
+  };
+
+  const onConfirm = async () => {
+    if (handleConfirm) {
+      await handleConfirm();
+    }
+    close();
+  };
+
+  return (
+    <Modal isOpen={true} onClose={onClose}>
+      <Modal.Content>
+        <ModalContentContainer>
+          <IconContainer>{icon}</IconContainer>
+          <TitleContainer>{title}</TitleContainer>
+          <ContentContainer>{content}</ContentContainer>
+          <Button onClick={onConfirm}>{confirmText}</Button>
+        </ModalContentContainer>
+      </Modal.Content>
+    </Modal>
+  );
+};
+
+const ModalContentContainer = styled("div")`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  padding: 40px 20px 28px 20px;
+  width: min-content;
+  min-width: 481px;
+  text-align: center;
+  white-space: pre-line;
+`;
+
+const IconContainer = styled("span")`
+  ${({ theme }) => theme.typography.header1};
+`;
+
+const TitleContainer = styled("span")`
+  ${({ theme }) => theme.typography.header1};
+  margin-top: 40px;
+`;
+
+const ContentContainer = styled("span")`
+  ${({ theme }) => theme.typography.md};
+  color: ${({ theme }) => theme.colors.black[300]};
+  border-radius: 16px;
+  background-color: ${({ theme }) => theme.colors.primary[50]};
+  padding: 16px 20px;
+  margin-top: 20px;
+  margin-bottom: 30px;
+`;

--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -10,7 +10,7 @@ export interface ConfirmModalProps {
   confirmText?: string;
   // Todo: any제거
   handleClose?: () => any;
-  handleConfirm?: () => any;
+  onConfirm?: () => any;
 }
 
 const ConfirmModal = ({
@@ -19,7 +19,7 @@ const ConfirmModal = ({
   confirmText = "확인",
   cancelText = "취소",
   handleClose,
-  handleConfirm,
+  onConfirm,
 }: ConfirmModalProps) => {
   const { close } = useModal();
 
@@ -30,10 +30,11 @@ const ConfirmModal = ({
     close();
   };
 
-  const onConfirm = async () => {
-    if (handleConfirm) {
-      await handleConfirm();
+  const handleConfirm = () => {
+    if (!onConfirm) {
+      return;
     }
+    onConfirm();
     close();
   };
 
@@ -45,7 +46,7 @@ const ConfirmModal = ({
           <ContentContainer>{content}</ContentContainer>
           <ButtonContainer>
             <Button
-              onClick={onConfirm}
+              onClick={handleConfirm}
               width="100%"
               variants="outlined"
               color="general"
@@ -68,6 +69,7 @@ const ModalContentContainer = styled("div")`
   display: flex;
   flex-direction: column;
   padding: 28px 32px;
+  background-color: white;
   width: min-content;
   min-width: 635px;
   white-space: pre-line;

--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import useModal from "hooks/useModal";
+import { Button, Modal } from "jci-moyeo-design-system";
+import styled from "styled-components";
+
+export interface ConfirmModalProps {
+  title?: string;
+  content?: string;
+  cancelText?: string;
+  confirmText?: string;
+  // Todo: any제거
+  handleClose?: () => any;
+  handleConfirm?: () => any;
+}
+
+const ConfirmModal = ({
+  title,
+  content,
+  confirmText = "확인",
+  cancelText = "취소",
+  handleClose,
+  handleConfirm,
+}: ConfirmModalProps) => {
+  const { close } = useModal();
+
+  const onClose = () => {
+    if (handleClose) {
+      handleClose();
+    }
+    close();
+  };
+
+  const onConfirm = async () => {
+    if (handleConfirm) {
+      await handleConfirm();
+    }
+    close();
+  };
+
+  return (
+    <Modal isOpen={true} onClose={onClose}>
+      <Modal.Content>
+        <ModalContentContainer>
+          <TitleContainer>{title}</TitleContainer>
+          <ContentContainer>{content}</ContentContainer>
+          <ButtonContainer>
+            <Button
+              onClick={onConfirm}
+              width="100%"
+              variants="outlined"
+              color="general"
+            >
+              {confirmText}
+            </Button>
+            <Button onClick={onClose} width="100%">
+              {cancelText}
+            </Button>
+          </ButtonContainer>
+        </ModalContentContainer>
+      </Modal.Content>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;
+
+const ModalContentContainer = styled("div")`
+  display: flex;
+  flex-direction: column;
+  padding: 28px 32px;
+  width: min-content;
+  min-width: 635px;
+  white-space: pre-line;
+`;
+
+const TitleContainer = styled("span")`
+  ${({ theme }) => theme.typography.header2};
+`;
+
+const ContentContainer = styled("span")`
+  ${({ theme }) => theme.typography.md};
+  color: ${({ theme }) => theme.colors.black[300]};
+  padding: 28px 0;
+`;
+
+const ButtonContainer = styled("div")`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 12px;
+`;

--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -9,7 +9,7 @@ export interface ConfirmModalProps {
   cancelText?: string;
   confirmText?: string;
   // Todo: any제거
-  handleClose?: () => any;
+  onClose?: () => any;
   onConfirm?: () => any;
 }
 
@@ -18,14 +18,14 @@ export const ConfirmModal = ({
   content,
   confirmText = "확인",
   cancelText = "취소",
-  handleClose,
+  onClose,
   onConfirm,
 }: ConfirmModalProps) => {
   const { close } = useModal();
 
-  const onClose = () => {
-    if (handleClose) {
-      handleClose();
+  const handleClose = () => {
+    if (onClose) {
+      onClose();
     }
     close();
   };
@@ -39,7 +39,7 @@ export const ConfirmModal = ({
   };
 
   return (
-    <Modal isOpen onClose={onClose}>
+    <Modal isOpen onClose={handleClose}>
       <Modal.Content>
         <ModalContentContainer>
           <TitleContainer>{title}</TitleContainer>
@@ -53,7 +53,7 @@ export const ConfirmModal = ({
             >
               {confirmText}
             </Button>
-            <Button onClick={onClose} width="100%">
+            <Button onClick={handleClose} width="100%">
               {cancelText}
             </Button>
           </ButtonContainer>

--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -13,7 +13,7 @@ export interface ConfirmModalProps {
   onConfirm?: () => any;
 }
 
-const ConfirmModal = ({
+export const ConfirmModal = ({
   title,
   content,
   confirmText = "확인",
@@ -39,7 +39,7 @@ const ConfirmModal = ({
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose}>
+    <Modal isOpen onClose={onClose}>
       <Modal.Content>
         <ModalContentContainer>
           <TitleContainer>{title}</TitleContainer>
@@ -63,13 +63,10 @@ const ConfirmModal = ({
   );
 };
 
-export default ConfirmModal;
-
 const ModalContentContainer = styled("div")`
   display: flex;
   flex-direction: column;
   padding: 28px 32px;
-  background-color: white;
   width: min-content;
   min-width: 635px;
   white-space: pre-line;

--- a/src/components/common/Modal/GlobalModal.tsx
+++ b/src/components/common/Modal/GlobalModal.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import { useRecoilState } from "recoil";
 import { AlertModal } from "./AlertModal";
 import { modalState } from "recoil/modal";
-import ConfirmModal from "./ConfirmModal";
+import { ConfirmModal } from "./ConfirmModal";
 
 export const MODAL_TYPES = {
   alert: "alert",
   confirm: "confirm",
 } as const;
 
-const MODAL_COMPONENTS: any = {
+const MODAL_COMPONENTS = {
   [MODAL_TYPES.confirm]: ConfirmModal,
   [MODAL_TYPES.alert]: AlertModal,
 };

--- a/src/components/common/Modal/GlobalModal.tsx
+++ b/src/components/common/Modal/GlobalModal.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useRecoilState } from "recoil";
+import { AlertModal } from "./AlertModal";
+import { modalState } from "recoil/modal";
+import ConfirmModal from "./ConfirmModal";
+
+export const MODAL_TYPES = {
+  alert: "alert",
+  confirm: "confirm",
+} as const;
+
+const MODAL_COMPONENTS: any = {
+  [MODAL_TYPES.confirm]: ConfirmModal,
+  [MODAL_TYPES.alert]: AlertModal,
+};
+
+export const GlobalModal = () => {
+  const { modalType, modalProps } = useRecoilState(modalState)[0] || {};
+
+  const renderComponent = () => {
+    if (!modalType) {
+      return null;
+    }
+    const ModalComponent = MODAL_COMPONENTS[modalType];
+
+    return <ModalComponent {...modalProps} />;
+  };
+
+  return <>{renderComponent()}</>;
+};

--- a/src/components/common/Modal/index.ts
+++ b/src/components/common/Modal/index.ts
@@ -1,0 +1,2 @@
+export * from "./AlertModal";
+export * from "./GlobalModal";

--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -3,8 +3,42 @@ import styled from "styled-components";
 import { Search } from "./Search";
 import { PostList } from "components/common/PostList";
 import Image from "next/image";
+import useModal from "hooks/useModal";
+import { Icon } from "jci-moyeo-design-system";
 
 const Main = () => {
+  const { open } = useModal();
+
+  // const handleClickAlertModal = () => {
+  //   open({
+  //     modalType: "alert",
+  //     modalProps: {
+  //       icon: <Icon name="checkInCircle" size={80} color="#06CBF7" />,
+  //       title: "모여에 오신걸\n환영합니다!",
+  //       content: `계정으로 회원가입이 성공적으로 완료되었습니다.\n아래 로그인 버튼을 눌러 다시한번 로그인 해주세요.`,
+  //       confirmText: "로그인",
+  //       handleConfirm: () => {
+  //         console.log("handle confirm");
+  //       },
+  //     },
+  //   });
+  // };
+
+  // const handleClickConfirmModal = () => {
+  //   open({
+  //     modalType: "confirm",
+  //     modalProps: {
+  //       title: "잠깐, 뒤로 가실 건가요?",
+  //       content: `지금까지 작성된 글이 모두 사라져요!\n그래도 뒤로 가시겠어요?`,
+  //       confirmText: "예",
+  //       cancelText: "아니요",
+  //       handleConfirm: () => {
+  //         console.log("handle confirm");
+  //       },
+  //     },
+  //   });
+  // };
+
   return (
     <>
       <SearchWrapper>
@@ -18,6 +52,8 @@ const Main = () => {
           height="32px"
         />
         <Title>프로젝트/스터디</Title>
+        {/* <button onClick={handleClickAlertModal}>alert modal</button>
+        <button onClick={handleClickConfirmModal}>confirm modal</button> */}
       </TitleContainer>
       <PostList postList={[]} />
     </>

--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -9,35 +9,35 @@ import { Icon } from "jci-moyeo-design-system";
 const Main = () => {
   const { open } = useModal();
 
-  // const handleClickAlertModal = () => {
-  //   open({
-  //     modalType: "alert",
-  //     modalProps: {
-  //       icon: <Icon name="checkInCircle" size={80} color="#06CBF7" />,
-  //       title: "모여에 오신걸\n환영합니다!",
-  //       content: `계정으로 회원가입이 성공적으로 완료되었습니다.\n아래 로그인 버튼을 눌러 다시한번 로그인 해주세요.`,
-  //       confirmText: "로그인",
-  //       handleConfirm: () => {
-  //         console.log("handle confirm");
-  //       },
-  //     },
-  //   });
-  // };
+  const handleClickAlertModal = () => {
+    open({
+      modalType: "alert",
+      modalProps: {
+        icon: <Icon name="checkInCircle" size={80} color="#06CBF7" />,
+        title: "모여에 오신걸\n환영합니다!",
+        content: `계정으로 회원가입이 성공적으로 완료되었습니다.\n아래 로그인 버튼을 눌러 다시한번 로그인 해주세요.`,
+        buttonText: "로그인",
+        onButtonClick: () => {
+          console.log("login");
+        },
+      },
+    });
+  };
 
-  // const handleClickConfirmModal = () => {
-  //   open({
-  //     modalType: "confirm",
-  //     modalProps: {
-  //       title: "잠깐, 뒤로 가실 건가요?",
-  //       content: `지금까지 작성된 글이 모두 사라져요!\n그래도 뒤로 가시겠어요?`,
-  //       confirmText: "예",
-  //       cancelText: "아니요",
-  //       handleConfirm: () => {
-  //         console.log("handle confirm");
-  //       },
-  //     },
-  //   });
-  // };
+  const handleClickConfirmModal = () => {
+    open({
+      modalType: "confirm",
+      modalProps: {
+        title: "잠깐, 뒤로 가실 건가요?",
+        content: `지금까지 작성된 글이 모두 사라져요!\n그래도 뒤로 가시겠어요?`,
+        confirmText: "예",
+        cancelText: "아니요",
+        onConfirm: () => {
+          console.log("예~!");
+        },
+      },
+    });
+  };
 
   return (
     <>
@@ -52,8 +52,8 @@ const Main = () => {
           height="32px"
         />
         <Title>프로젝트/스터디</Title>
-        {/* <button onClick={handleClickAlertModal}>alert modal</button>
-        <button onClick={handleClickConfirmModal}>confirm modal</button> */}
+        <button onClick={handleClickAlertModal}>alert modal</button>
+        <button onClick={handleClickConfirmModal}>confirm modal</button>
       </TitleContainer>
       <PostList postList={[]} />
     </>

--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -9,35 +9,35 @@ import { Icon } from "jci-moyeo-design-system";
 const Main = () => {
   const { open } = useModal();
 
-  const handleClickAlertModal = () => {
-    open({
-      modalType: "alert",
-      modalProps: {
-        icon: <Icon name="checkInCircle" size={80} color="#06CBF7" />,
-        title: "모여에 오신걸\n환영합니다!",
-        content: `계정으로 회원가입이 성공적으로 완료되었습니다.\n아래 로그인 버튼을 눌러 다시한번 로그인 해주세요.`,
-        buttonText: "로그인",
-        onButtonClick: () => {
-          console.log("login");
-        },
-      },
-    });
-  };
+  // const handleClickAlertModal = () => {
+  //   open({
+  //     modalType: "alert",
+  //     modalProps: {
+  //       icon: <Icon name="checkInCircle" size={80} color="#06CBF7" />,
+  //       title: "모여에 오신걸\n환영합니다!",
+  //       content: `계정으로 회원가입이 성공적으로 완료되었습니다.\n아래 로그인 버튼을 눌러 다시한번 로그인 해주세요.`,
+  //       buttonText: "로그인",
+  //       onButtonClick: () => {
+  //         console.log("login");
+  //       },
+  //     },
+  //   });
+  // };
 
-  const handleClickConfirmModal = () => {
-    open({
-      modalType: "confirm",
-      modalProps: {
-        title: "잠깐, 뒤로 가실 건가요?",
-        content: `지금까지 작성된 글이 모두 사라져요!\n그래도 뒤로 가시겠어요?`,
-        confirmText: "예",
-        cancelText: "아니요",
-        onConfirm: () => {
-          console.log("예~!");
-        },
-      },
-    });
-  };
+  // const handleClickConfirmModal = () => {
+  //   open({
+  //     modalType: "confirm",
+  //     modalProps: {
+  //       title: "잠깐, 뒤로 가실 건가요?",
+  //       content: `지금까지 작성된 글이 모두 사라져요!\n그래도 뒤로 가시겠어요?`,
+  //       confirmText: "예",
+  //       cancelText: "아니요",
+  //       onConfirm: () => {
+  //         console.log("예~!");
+  //       },
+  //     },
+  //   });
+  // };
 
   return (
     <>
@@ -52,8 +52,8 @@ const Main = () => {
           height="32px"
         />
         <Title>프로젝트/스터디</Title>
-        <button onClick={handleClickAlertModal}>alert modal</button>
-        <button onClick={handleClickConfirmModal}>confirm modal</button>
+        {/* <button onClick={handleClickAlertModal}>alert modal</button>
+        <button onClick={handleClickConfirmModal}>confirm modal</button> */}
       </TitleContainer>
       <PostList postList={[]} />
     </>

--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -9,35 +9,35 @@ import { Icon } from "jci-moyeo-design-system";
 const Main = () => {
   const { open } = useModal();
 
-  // const handleClickAlertModal = () => {
-  //   open({
-  //     modalType: "alert",
-  //     modalProps: {
-  //       icon: <Icon name="checkInCircle" size={80} color="#06CBF7" />,
-  //       title: "모여에 오신걸\n환영합니다!",
-  //       content: `계정으로 회원가입이 성공적으로 완료되었습니다.\n아래 로그인 버튼을 눌러 다시한번 로그인 해주세요.`,
-  //       buttonText: "로그인",
-  //       onButtonClick: () => {
-  //         console.log("login");
-  //       },
-  //     },
-  //   });
-  // };
+  const handleClickAlertModal = () => {
+    open({
+      modalType: "alert",
+      modalProps: {
+        icon: <Icon name="checkInCircle" size={80} color="#06CBF7" />,
+        title: "모여에 오신걸\n환영합니다!",
+        content: `계정으로 회원가입이 성공적으로 완료되었습니다.\n아래 로그인 버튼을 눌러 다시한번 로그인 해주세요.`,
+        buttonText: "로그인",
+        onButtonClick: () => {
+          console.log("login");
+        },
+      },
+    });
+  };
 
-  // const handleClickConfirmModal = () => {
-  //   open({
-  //     modalType: "confirm",
-  //     modalProps: {
-  //       title: "잠깐, 뒤로 가실 건가요?",
-  //       content: `지금까지 작성된 글이 모두 사라져요!\n그래도 뒤로 가시겠어요?`,
-  //       confirmText: "예",
-  //       cancelText: "아니요",
-  //       onConfirm: () => {
-  //         console.log("예~!");
-  //       },
-  //     },
-  //   });
-  // };
+  const handleClickConfirmModal = () => {
+    open({
+      modalType: "confirm",
+      modalProps: {
+        title: "잠깐, 뒤로 가실 건가요?",
+        content: `지금까지 작성된 글이 모두 사라져요!\n그래도 뒤로 가시겠어요?`,
+        confirmText: "예",
+        cancelText: "아니요",
+        onConfirm: () => {
+          console.log("예~!");
+        },
+      },
+    });
+  };
 
   return (
     <>
@@ -52,8 +52,8 @@ const Main = () => {
           height="32px"
         />
         <Title>프로젝트/스터디</Title>
-        {/* <button onClick={handleClickAlertModal}>alert modal</button>
-        <button onClick={handleClickConfirmModal}>confirm modal</button> */}
+        <button onClick={handleClickAlertModal}>alert modal</button>
+        <button onClick={handleClickConfirmModal}>confirm modal</button>
       </TitleContainer>
       <PostList postList={[]} />
     </>

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -13,8 +13,6 @@ export default function useModal() {
   };
 
   return {
-    modal,
-    setModal,
     open,
     close,
   };

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,21 @@
+import { useRecoilState } from "recoil";
+import { ModalType, modalState } from "recoil/modal";
+
+export default function useModal() {
+  const [modal, setModal] = useRecoilState(modalState);
+
+  const open = ({ modalType, modalProps }: ModalType) => {
+    setModal({ modalType, modalProps });
+  };
+
+  const close = () => {
+    setModal(null);
+  };
+
+  return {
+    modal,
+    setModal,
+    open,
+    close,
+  };
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { ThemeProvider } from "styled-components";
 import { GlobalStyle, Theme } from "jci-moyeo-design-system";
 import "../styles/toastui.css";
 import { NextPage, NextPageContext } from "next";
+import { GlobalModal } from "components/common/Modal";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
@@ -47,7 +48,10 @@ function MoyeoApp({ Component, pageProps }: AppPropsWithLayout) {
       <GlobalStyle />
       <QueryClientProvider client={queryClient}>
         <Hydrate state={dehydratedState}>
-          <RecoilRoot>{getLayout(<Component {...rest} />)}</RecoilRoot>
+          <RecoilRoot>
+            {getLayout(<Component {...rest} />)}
+            <GlobalModal />
+          </RecoilRoot>
         </Hydrate>
       </QueryClientProvider>
     </ThemeProvider>

--- a/src/recoil/modal.ts
+++ b/src/recoil/modal.ts
@@ -1,0 +1,21 @@
+import { AlertModalProps } from "components/common/Modal/AlertModal";
+import { ConfirmModalProps } from "components/common/Modal/ConfirmModal";
+import { MODAL_TYPES } from "components/common/Modal/GlobalModal";
+import { atom } from "recoil";
+
+export interface ConfirmModalType {
+  modalType: typeof MODAL_TYPES.confirm;
+  modalProps: ConfirmModalProps;
+}
+
+export interface AlertModalType {
+  modalType: typeof MODAL_TYPES.alert;
+  modalProps: AlertModalProps;
+}
+
+export type ModalType = ConfirmModalType | AlertModalType;
+
+export const modalState = atom<ModalType | null>({
+  key: "modalState",
+  default: null,
+});

--- a/src/recoil/modal.ts
+++ b/src/recoil/modal.ts
@@ -3,17 +3,10 @@ import { ConfirmModalProps } from "components/common/Modal/ConfirmModal";
 import { MODAL_TYPES } from "components/common/Modal/GlobalModal";
 import { atom } from "recoil";
 
-export interface ConfirmModalType {
-  modalType: typeof MODAL_TYPES.confirm;
-  modalProps: ConfirmModalProps;
+export interface ModalType {
+  modalType: typeof MODAL_TYPES.confirm | typeof MODAL_TYPES.alert;
+  modalProps: ConfirmModalProps | AlertModalProps;
 }
-
-export interface AlertModalType {
-  modalType: typeof MODAL_TYPES.alert;
-  modalProps: AlertModalProps;
-}
-
-export type ModalType = ConfirmModalType | AlertModalType;
 
 export const modalState = atom<ModalType | null>({
   key: "modalState",


### PR DESCRIPTION
## 설명

- Modal.open으로 modal 띄울 수 있도록 개발

## 작업내용

- recoil/modal
- useModal
- Alert / Confirm 두가지 형태로 개발
- `modalType`, `modalProps` (title, content, icon, confirmText, onConfirm 등) 지정 가능

## 스크린샷 (Optional)
![2022-11-04 17 54 50](https://user-images.githubusercontent.com/66931791/199932892-e3c33ca3-ffa3-447c-94d7-90184bd68e96.gif)
